### PR TITLE
Bug: Characters in old readme files can cause problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
 # Changelog
 
-## [UNRELEASED](https://github.com/UAL-ODIS/LD-Cool-P/tree/HEAD) (YYYY-MM-DD)
-
-**Implemented enhancements:**
- - `______` [#XX](http://github.com/UAL-ODIS/LD-Cool-P/pull/XX)
+## [v1.1.1](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.1) (2021-06-10)
 
 **Fixed bugs:**
- - `______` [#XX](http://github.com/UAL-ODIS/LD-Cool-P/issues/XX)
+ - Bug: Characters in old readme files can cause problems [#220](http://github.com/UAL-ODIS/LD-Cool-P/issues/220)
 
 **Closed issues:**
  - Delete populate and strip module from curation.inspection.readme [#218](http://github.com/UAL-ODIS/LD-Cool-P/issues/218)
 
 **Merged pull requests:**
  - Delete populate and strip module from curation.inspection.readme [#219](http://github.com/UAL-ODIS/LD-Cool-P/pull/219)
+ - Bug: Characters in old readme files can cause problems [#221](http://github.com/UAL-ODIS/LD-Cool-P/issues/221)
 
 
 ## [v1.1.0](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.0) (2021-06-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 **Merged pull requests:**
  - Delete populate and strip module from curation.inspection.readme [#219](http://github.com/UAL-ODIS/LD-Cool-P/pull/219)
- - Bug: Characters in old readme files can cause problems [#221](http://github.com/UAL-ODIS/LD-Cool-P/issues/221)
+ - Bug: Characters in old readme files can cause problems [#221](http://github.com/UAL-ODIS/LD-Cool-P/pull/221)
 
 
 ## [v1.1.0](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.0) (2021-06-07)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.1.0`.
+You should see that the version is `1.1.1`.
 
 ### Configuration Settings
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -416,7 +416,7 @@ class ReadmeClass:
             else:
                 self.log.info("README.txt changed. Updating!")
                 st = stat(self.readme_file_path)
-                mod_time_str = datetime.fromtimestamp(st.st_mtime).strftime('%Y-%m-%d_%H:%M:%S')
+                mod_time_str = datetime.fromtimestamp(st.st_mtime).strftime('%Y-%m-%d_%H.%M.%S')
                 backup_copy_filename = self.readme_file_path.replace('.txt', f'_{mod_time_str}.txt')
                 self.log.info(f"Saving previous copy as : {basename(backup_copy_filename)}")
                 shutil.copyfile(self.readme_file_path, backup_copy_filename)

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -416,7 +416,9 @@ class ReadmeClass:
             else:
                 self.log.info("README.txt changed. Updating!")
                 st = stat(self.readme_file_path)
-                mod_time_str = datetime.fromtimestamp(st.st_mtime).strftime('%Y-%m-%d_%H.%M.%S')
+                mod_time = datetime.fromtimestamp(st.st_mtime)
+                mod_time_str = mod_time.isoformat(timespec='seconds').\
+                    replace(':', '')
                 backup_copy_filename = self.readme_file_path.replace('.txt', f'_{mod_time_str}.txt')
                 self.log.info(f"Saving previous copy as : {basename(backup_copy_filename)}")
                 shutil.copyfile(self.readme_file_path, backup_copy_filename)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='1.1.0',
+    version='1.1.1',
     packages=['ldcoolp'],
     url='https://github.com/UAL-ODIS/LD-Cool-P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
A simple fix to change the `strftime` to not use colon. This doesn't require testing.

<!-- Add any linked issue(s) -->
Fixes #220


**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] CHANGELOG.md


**Bump version**

v1.1.0 -> v1.1.1

- [x] README.md, [installation instructions](../../README.md#installation-instructions)
- [x] [`setup.py`](../../setup.py)
- [x] [`ldcoolp/__init__.py`](../../ldcoolp/__init__.py)
