### PR TITLE
Enhancement: Double digit for version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [UNRELEASED](https://github.com/UAL-ODIS/LD-Cool-P/tree/HEAD) (YYYY-MM-DD)
+
+**Implemented enhancements:**
+ - Enhancement: Double digit for version [#225](http://github.com/UAL-ODIS/LD-Cool-P/pull/225)
+
+**Closed issues:**
+ - Enhancement: Double digit for version [#224](http://github.com/UAL-ODIS/LD-Cool-P/issues/224)
+
+
 ## [v1.1.1](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.1) (2021-06-10)
 
 **Fixed bugs:**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.1.2`.
+You should see that the version is `1.1.3`.
 
 ### Configuration Settings
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/depositor_name.py
+++ b/ldcoolp/curation/depositor_name.py
@@ -146,7 +146,7 @@ class DepositorName:
             folderName = f"{temp_name}-{first_author}"
 
         # Add article_id and version number
-        folderName += f"_{self.article_id}/v{self.version_no}"
+        folderName += f"_{self.article_id}/v{self.version_no:02}"
 
         if self.verbose:
             self.log.info(f"depository_name : {folderName}")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='1.1.2',
+    version='1.1.3',
     packages=['ldcoolp'],
     url='https://github.com/UAL-ODIS/LD-Cool-P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->
This directly fixes the need to use zero padding on folder name (e.g., "v01")

<!-- Add any linked issue(s) -->
Closes #224

**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

 - [x] Retrieve data with `get_data`
 - [x] Move folder with `move_next`, `move_back` and `move_publish`

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] CHANGELOG.md updated for unreleased changes

*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->

To update existing files using old schema for version:
```
ls -d /mnt/block1_sfo2/curation/*/*/v? | awk '{printf("mv %s ", $0); sub(/\/v/,"\/v0"); print}' | sh
```
