### PR TITLE
Enhancement: Dump JSON metadata from Qualtrics API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [v1.1.2](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.2) (2021-06-28)
 
 **Implemented enhancements:**
- -  Enhancement: Dump JSON metadata from Qualtrics API
-    [#226](https://github.com/UAL-ODIS/LD-Cool-P/pull/226)
  - Allow for downloading only the metadata
    [#223](https://github.com/UAL-ODIS/LD-Cool-P/pull/223)
+ - Enhancement: Dump JSON metadata from Qualtrics API
+   [#226](https://github.com/UAL-ODIS/LD-Cool-P/pull/226)
 
 **Closed issues:**
  - Enhancement: Dump JSON metadata from Qualtrics API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [UNRELEASED](https://github.com/UAL-ODIS/LD-Cool-P/tree/HEAD) (YYYY-MM-DD)
+
+**Implemented enhancements:**
+ -  Enhancement: Dump JSON metadata from Qualtrics API
+    [#226](https://github.com/UAL-ODIS/LD-Cool-P/pull/226)
+
+**Closed issues:**
+ - Enhancement: Dump JSON metadata from Qualtrics API
+   [#160](https://github.com/UAL-ODIS/LD-Cool-P/issues/160)
+
+
 ## [v1.1.1](https://github.com/UAL-ODIS/LD-Cool-P/tree/v1.1.1) (2021-06-10)
 
 **Fixed bugs:**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.1.1`.
+You should see that the version is `1.1.2`.
 
 ### Configuration Settings
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -575,8 +575,6 @@ class Qualtrics:
             qualtrics_dict['references'] = []
         else:
             qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
-            self.save_metadata(qualtrics_dict, dn, out_file_prefix=
-                               f"readme_original_{dn.name_dict['article_id']}")
             for key in qualtrics_dict.keys():
                 if isinstance(qualtrics_dict[key], float):
                     qualtrics_dict[key] = str(qualtrics_dict[key])
@@ -607,6 +605,10 @@ class Qualtrics:
         qualtrics_dict['corr_author_fullname'] = DA_dict['Q6_1']
         qualtrics_dict['corr_author_email'] = DA_dict['Q6_2']
         qualtrics_dict['corr_author_affil'] = DA_dict['Q6_3']
+
+        # Save Qualtrics README metadata
+        self.save_metadata(qualtrics_dict, dn, out_file_prefix=
+                           f"readme_original_{dn.name_dict['article_id']}")
 
         return qualtrics_dict
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -52,13 +52,7 @@ class Qualtrics:
       A Python interface for interaction with Qualtrics API for Deposit
       Agreement form survey
 
-    :param qualtrics_dict: Dict that contains Qualtrics configuration.
-      This should include:
-        - survey_id
-        - token
-        - datacenter
-        - download_url
-        - generate_url
+    :param config_dict: Dict that contains LD-Cool-P configuration.
 
       Default: config_default_dict from config/default.ini
 
@@ -110,12 +104,13 @@ class Qualtrics:
       Generate URL with customized query strings based on Figshare metadata
     """
 
-    def __init__(self, qualtrics_dict=config_default_dict['qualtrics'], log=None,
+    def __init__(self, config_dict=config_default_dict, log=None,
                  interactive=True):
 
         self.interactive = interactive
 
-        self.dict = qualtrics_dict
+        self.curation_dict = config_dict['curation']
+        self.dict = config_dict['qualtrics']
         self.token = self.dict['token']
         self.data_center = self.dict['datacenter']
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -540,7 +540,8 @@ class Qualtrics:
                 self.log.warn("Multiple entries found")
                 raise ValueError
 
-    def retrieve_qualtrics_readme(self, dn=None, ResponseId='', browser=True):
+    def retrieve_qualtrics_readme(self, dn=None, ResponseId='', browser=True,
+                                  save_metadata: bool = False):
         """Retrieve response to Qualtrics README form"""
 
         if ResponseId:
@@ -607,8 +608,11 @@ class Qualtrics:
         qualtrics_dict['corr_author_affil'] = DA_dict['Q6_3']
 
         # Save Qualtrics README metadata
-        self.save_metadata(qualtrics_dict, dn, out_file_prefix=
-                           f"readme_original_{dn.name_dict['article_id']}")
+        if save_metadata:
+            out_file_prefix = "qualtrics_readme_original_" + \
+                              f"{dn.name_dict['article_id']}"
+            self.save_metadata(qualtrics_dict, dn,
+                               out_file_prefix=out_file_prefix)
 
         return qualtrics_dict
 

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -24,6 +24,7 @@ import webbrowser
 
 # Convert single-entry DataFrame to dictionary
 from ldcoolp.curation import df_to_dict_single
+from ldcoolp.curation import metadata
 
 # Logging
 from redata.commons.logger import log_stdout
@@ -604,3 +605,20 @@ class Qualtrics:
         qualtrics_dict['corr_author_affil'] = DA_dict['Q6_3']
 
         return qualtrics_dict
+
+    def save_metadata(self, response_dict: dict, dn: DepositorName,
+                      out_file_prefix: str = 'qualtrics'):
+        """Save Qualtrics metadata to JSON file"""
+
+        root_directory = join(
+            self.curation_dict[self.curation_dict['parent_dir']],
+            self.curation_dict['folder_todo'],
+            dn.folderName
+        )
+        metadata_directory = self.curation_dict['folder_metadata']
+
+        metadata.save_metadata(response_dict, out_file_prefix,
+                               metadata_source='QUALTRICS',
+                               root_directory=root_directory,
+                               metadata_directory=metadata_directory,
+                               log=self.log)

--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -295,6 +295,8 @@ class Qualtrics:
         else:
             if response_df.shape[0] == 1:
                 response_dict = df_to_dict_single(response_df)
+                self.save_metadata(response_dict, dn, out_file_prefix=
+                                   f'deposit_agreement_original_{article_id}')
                 self.pandas_write_buffer(response_df[cols_order])
                 self.log.info("Only one entry found!")
                 self.log.info(f"Survey completed on {response_dict['Date Completed']}")
@@ -573,6 +575,8 @@ class Qualtrics:
             qualtrics_dict['references'] = []
         else:
             qualtrics_dict = df_to_dict_single(response_df[readme_custom_content])
+            self.save_metadata(qualtrics_dict, dn, out_file_prefix=
+                               f"readme_original_{dn.name_dict['article_id']}")
             for key in qualtrics_dict.keys():
                 if isinstance(qualtrics_dict[key], float):
                     qualtrics_dict[key] = str(qualtrics_dict[key])

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -87,8 +87,9 @@ class ReadmeClass:
       Construct README.txt by calling retrieve
     """
 
-    def __init__(self, dn, config_dict=config_default_dict, update=False,
-                 q: Qualtrics = None, interactive=True, log=None):
+    def __init__(self, dn: DepositorName, config_dict=config_default_dict,
+                 update=False, q: Qualtrics = None, interactive=True,
+                 log=None):
         self.config_dict = config_dict
         self.interactive = interactive
 

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -123,7 +123,7 @@ class ReadmeClass:
         if q:
             self.q = q
         else:
-            self.q = Qualtrics(qualtrics_dict=self.config_dict['qualtrics'],
+            self.q = Qualtrics(config_dict=self.config_dict,
                                interactive=interactive, log=self.log)
 
         self.curation_dict = self.config_dict['curation']

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -427,6 +427,13 @@ class ReadmeClass:
                 f = open(self.readme_file_path, 'w')
                 f.writelines(content_list)
                 f.close()
+
+                # Saving Qualtrics README for metadata for updated README.txt
+                cur_time = datetime.now()
+                out_file_prefix = f"readme_revised_{self.article_id}_" + \
+                                  f"{cur_time.isoformat(timespec='seconds').replace(':', '')}"
+                self.q.save_metadata(self.qualtrics_readme_dict, self.dn,
+                                     out_file_prefix=out_file_prefix)
         else:
             self.log.info("README.txt does not exist. Creating new one")
 

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -475,7 +475,7 @@ class ReadmeClass:
         metadata_directory = self.curation_dict['folder_metadata']
 
         metadata.save_metadata(response_dict, out_file_prefix,
-                               metadata_source='QUALTRICS',
+                               metadata_source='README',
                                root_directory=root_directory,
                                metadata_directory=metadata_directory,
                                log=self.log)

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -174,7 +174,7 @@ def workflow(article_id, url_open=False, browser=True, log=None,
             curation_dict['folder_ual_rdm'],
         )
         log.debug(f"out_path: {out_path}")
-        q = Qualtrics(qualtrics_dict=config_dict['qualtrics'], log=log)
+        q = Qualtrics(config_dict=config_dict, log=log)
         q.retrieve_deposit_agreement(pw.dn.name_dict, out_path=out_path,
                                      browser=browser)
 

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -175,7 +175,7 @@ def workflow(article_id, url_open=False, browser=True, log=None,
         )
         log.debug(f"out_path: {out_path}")
         q = Qualtrics(config_dict=config_dict, log=log)
-        q.retrieve_deposit_agreement(pw.dn.name_dict, out_path=out_path,
+        q.retrieve_deposit_agreement(pw.dn, out_path=out_path,
                                      browser=browser)
 
         # Check for README file and create one if it does not exist

--- a/ldcoolp/curation/metadata.py
+++ b/ldcoolp/curation/metadata.py
@@ -10,6 +10,7 @@ from redata.commons.logger import log_stdout
 
 def save_metadata(json_response: Union[list, dict],
                   out_file_prefix: str,
+                  metadata_source: str = 'CURATION',
                   root_directory: str = '',
                   metadata_directory: str = '',
                   save_csv: bool = False,
@@ -23,6 +24,7 @@ def save_metadata(json_response: Union[list, dict],
     :param root_directory: Full path containing the working directory
     :param metadata_directory: Metadata path
     :param save_csv: Save a CSV file. Default: False
+    :param metadata_source: Source of metadata,
     :param log: LogClass or logging object. Default: log_stdout()
     """
 
@@ -31,7 +33,7 @@ def save_metadata(json_response: Union[list, dict],
 
     log.debug("starting ...")
     log.info("")
-    log.info("** SAVING CURATION METADATA **")
+    log.info(f"** SAVING {metadata_source} METADATA **")
 
     if not root_directory:
         root_directory = os.getcwd()

--- a/ldcoolp/curation/metadata.py
+++ b/ldcoolp/curation/metadata.py
@@ -14,6 +14,7 @@ def save_metadata(json_response: Union[list, dict],
                   root_directory: str = '',
                   metadata_directory: str = '',
                   save_csv: bool = False,
+                  overwrite: bool = False,
                   log=None):
 
     """
@@ -21,10 +22,11 @@ def save_metadata(json_response: Union[list, dict],
 
     :param json_response: Content in list or dict
     :param out_file_prefix: Filename prefix. Appends .json and .csv
+    :param metadata_source: Source of metadata,
     :param root_directory: Full path containing the working directory
     :param metadata_directory: Metadata path
     :param save_csv: Save a CSV file. Default: False
-    :param metadata_source: Source of metadata,
+    :param overwrite: Overwrite file if it exists. Default: False
     :param log: LogClass or logging object. Default: log_stdout()
     """
 
@@ -45,17 +47,30 @@ def save_metadata(json_response: Union[list, dict],
     # Write JSON file
     json_out_file = f"{out_file_prefix}.json"
     if not os.path.exists(json_out_file):
-        log.info(f"Writing: {json_out_file}")
-        with open(json_out_file, 'w') as f:
-            json.dump(json_response, f, indent=4)
+        write_json(json_out_file, json_response, log)
     else:
-        log.info(f"File exists: {out_file_prefix}")
+        log.info(f"File exists: {json_out_file}")
+        if overwrite:
+            log.info("Overwriting!")
+            write_json(json_out_file, json_response, log)
 
     # Write CSV file
     if save_csv:
-        csv_out_file = f"{out_file_prefix}.csv"
         df = pd.DataFrame.from_dict(json_response, orient='columns')
-        log.info(f"Writing: {csv_out_file}")
-        df.to_csv(csv_out_file, index=False)
+        csv_out_file = f"{out_file_prefix}.csv"
+        if not os.path.exists(csv_out_file):
+            log.info(f"Writing: {csv_out_file}")
+            df.to_csv(csv_out_file, index=False)
+        else:
+            log.info(f"File exists: {csv_out_file}")
+            if overwrite:
+                log.info("Overwriting!")
+                df.to_csv(csv_out_file, index=False)
 
     log.debug("finished.")
+
+
+def write_json(json_out_file, json_response, log):
+    log.info(f"Writing: {json_out_file}")
+    with open(json_out_file, 'w') as f:
+        json.dump(json_response, f, indent=4)

--- a/ldcoolp/scripts/generate_qualtrics_links
+++ b/ldcoolp/scripts/generate_qualtrics_links
@@ -79,8 +79,7 @@ if __name__ == '__main__':
     fs_dict = config_dict['figshare']
     fs_admin = FigshareInstituteAdmin(**fs_dict, log=log)
 
-    q_dict = config_dict['qualtrics']
-    q = qualtrics.Qualtrics(qualtrics_dict=q_dict, log=log)
+    q = qualtrics.Qualtrics(config_dict=config_dict, log=log)
 
     dn = depositor_name.DepositorName(args.article_id, fs_admin, verbose=False)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='1.1.1',
+    version='1.1.2',
     packages=['ldcoolp'],
     url='https://github.com/UAL-ODIS/LD-Cool-P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->
This feature will write the Qualtrics metadata for the deposit agreement, as well as, the Figshare+Qualtrics metadata for the README form.

<!-- Add any linked issue(s) -->
Closes #160


**ToDo List**
 - [x] Bump version: v1.1.1 -> v1.1.2

**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

 Testing already indicated in the issue

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] CHANGELOG.md


*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->

Here is the result of retrieving a dataset and updating it:
<details>

For the Qualtrics Deposit Agreement:
```
14:10:12 -     INFO: ** CREATING CURATION REVIEW REPORT **
14:10:12 -     INFO: Creating folder : ****/1.ToDo/Martha_Farella_12904412/v1/UAL_RDM
14:10:12 -     INFO: Saving ReDATA Curation Report to: ****/1.ToDo/Martha_Farella_12904412/v1/UAL_RDM
14:10:12 -     INFO: Saving as : ReDATA-DepositReview_Martha_Farella_12904412_v1.docx
14:10:13 -     INFO: 
14:10:13 -     INFO: ** RETRIEVING DEPOSIT AGREEMENT **
14:10:18 -     INFO: Attempting to identify using article_id or curation_id ...
14:10:18 -     INFO: Unique match based on article_id or curation_id !
14:10:18 -     INFO: 
14:10:18 -     INFO: ** SAVING QUALTRICS METADATA **
14:10:18 -     INFO: Writing: ****/1.ToDo/Martha_Farella_12904412/v1/METADATA/deposit_agreement_original_12904412.json
```

For the README metadata:
```
14:10:44 -     INFO: Saving Main.md template in METADATA ...
14:10:44 -     INFO: Source file name: ****/LD_Cool_P/ldcoolp/curation/inspection/readme/templates/Main.md
14:10:45 -     INFO: Constructing README.txt file based on default template ...
14:10:45 -     INFO: Writing file : ****/1.ToDo/Martha_Farella_12904412/v1/DATA/README.txt
14:10:45 -     INFO: 
14:10:45 -     INFO: ** SAVING README METADATA **
14:10:45 -     INFO: Writing: ****/1.ToDo/Martha_Farella_12904412/v1/METADATA/readme_original_12904412.json
14:10:45 -     INFO: PROMPT: Do you wish to move deposit to the next curation stage?
```

Also when an update is triggered:
```
14:15:25 -     INFO: ** SELECTING README TEMPLATE **
14:15:25 -     INFO: ****/1.ToDo/Martha_Farella_12904412/v1/METADATA/Main.md exists. Not overwriting template!
14:15:25 -     INFO: ****/1.ToDo/Martha_Farella_12904412/v1/METADATA/README_template.md symbolic file link exists. Not overwriting!
14:15:25 -     INFO: README.txt changed. Updating!
14:15:25 -     INFO: Saving previous copy as : README_2021-06-24T141452.txt
14:15:25 -     INFO: Writing updated README.txt file : ****/1.ToDo/Martha_Farella_12904412/v1/DATA/README.txt
14:15:25 -     INFO: 
14:15:25 -     INFO: ** SAVING README METADATA **
14:15:25 -     INFO: Writing: ****/1.ToDo/Martha_Farella_12904412/v1/METADATA/readme_revised_12904412_2021-06-24T141525.json
14:15:25 -     INFO: Completed: 12904412 ...
14:15:25 -     INFO: Completed: 1 / 1
14:15:25 -     INFO: *********************************
```

</details>